### PR TITLE
fix: auto redirect logged in admin to dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import ProtectedRoutes from "./components/protected_route/ProtectedRoutes";
 import Dashboard from "./pages/dashboard/Dashboard";
@@ -6,8 +6,16 @@ import Login from "./pages/login/Login";
 import NotFound from "./pages/not_found/Not_Found";
 import Users from "./pages/users/Users";
 import User from "./pages/users/user/User";
+import { useAppDispatch } from "./hooks/useAppDispatch";
+import { getCurrentUserHandler } from "./actions/auth.actions";
 
 const App: FC = () => {
+	const dispatch = useAppDispatch();
+
+	useEffect(() => {
+		dispatch(getCurrentUserHandler());
+	}, []);
+
 	return (
 		<BrowserRouter>
 			<Routes>

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import Tooltip from "../../components/tooltip/Tooltip";
@@ -15,16 +15,29 @@ import { useFormik } from "formik";
 import { loginHandler } from "../../actions/auth.actions";
 import { useAppDispatch } from "../../hooks/useAppDispatch";
 import Button from "../../components/button/Button";
+import { useAppSelector } from "../../hooks/useAppSelector";
+import { TRootState } from "../../store";
 
 const Login: FC = () => {
 	const dispatch = useAppDispatch();
 	const navigate = useNavigate();
+
+	const { currentUser } = useAppSelector((state: TRootState) => state.users);
 
 	const [canShowTooltip, setCanShowTooltip] = useState<boolean>(false);
 	const [tooltipMessage, setTooltipMessage] = useState<string>("");
 	const [tooltipType, setTooltipType] = useState<"error" | "success">(
 		"success"
 	);
+
+	/**
+	 * This useEffect will redirect user to dashboard if he is already logged in
+	 *
+	 * @author aayushchugh
+	 */
+	useEffect(() => {
+		if (currentUser) navigate("/dashboard");
+	}, [currentUser]);
 
 	/**
 	 * form initial values


### PR DESCRIPTION
### Description

when admin opens the website and if he logged in previously than he will need not to login again
and will be redirected to dashboard automatically

### Checklist:

- [x] This pull request follow our contribution guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (postman and swagger)
- [ ] I have written tests for the code
- [ ] I have updated .env.example file for new .env variables

### What is current behavior?

Fixes #79 

### What is new behavior?

![Recording 2022-12-21 at 19 54 24](https://user-images.githubusercontent.com/69336518/208927821-ab533fd4-2f14-482a-bc09-8185bcd68664.gif)
